### PR TITLE
Imprv/#272 add updating emoji method to usecase and endpoint

### DIFF
--- a/src/routes/directories.ts
+++ b/src/routes/directories.ts
@@ -16,6 +16,7 @@ import { DeleteDirectoryUseCase } from '../usecases/directory/DeleteDirectoryUse
 import { FindDirectoryUseCase } from '../usecases/directory/FindDirectoryUseCase';
 import { FindChildrenDirectoriesUseCase } from '../usecases/directory/FindChildrenDirectoriesUseCase';
 import { UpdateOrderOfDirectoryUseCase } from '../usecases/directory/UpdateOrderOfDirectoryUseCase';
+import { UpdateEmojiOfDirectoryUsecase } from '../usecases/directory/UpdateEmojiOfDirectoryUseCase';
 import { FindPageListByDirectoryIdUseCase } from '../usecases/page/FindPageListByDirectoryIdUseCase';
 
 import { PageRepository } from '../infrastructure/PageRepository';
@@ -52,6 +53,7 @@ const validator = {
   updateDescription: [param('id').isMongoId(), body('description').isString()],
   updatePages: [param('id').isMongoId(), body('pages').isArray()],
   deleteDirectory: [param('id').isMongoId()],
+  updateEmoji: [param('id').isMongoId(), body('emoji').isInt()],
 };
 
 export const directories = (): Router => {
@@ -457,6 +459,24 @@ export const directories = (): Router => {
 
     try {
       const result = await useCase.execute(id, user);
+
+      return res.status(200).json(result);
+    } catch (err) {
+      console.log(err);
+      return res.status(500).json({ message: err.message });
+    }
+  });
+
+  // TODO: add swagger by #273
+  router.put('/:id/emoji', accessTokenParser, loginRequired, validator.updateEmoji, apiValidatorMiddleware, async (req: WebevRequest, res: Response) => {
+    const { id } = req.params;
+    const { emoji } = req.body;
+
+    const directoryRepository = new DirectoryRepository();
+    const usecase = new UpdateEmojiOfDirectoryUsecase(directoryRepository);
+
+    try {
+      const result = await usecase.execute(id, emoji);
 
       return res.status(200).json(result);
     } catch (err) {

--- a/src/routes/directories.ts
+++ b/src/routes/directories.ts
@@ -53,7 +53,7 @@ const validator = {
   updateDescription: [param('id').isMongoId(), body('description').isString()],
   updatePages: [param('id').isMongoId(), body('pages').isArray()],
   deleteDirectory: [param('id').isMongoId()],
-  updateEmoji: [param('id').isMongoId(), body('emoji').isInt()],
+  updateEmoji: [param('id').isMongoId(), body('emoji').isString()],
 };
 
 export const directories = (): Router => {

--- a/src/routes/directories.ts
+++ b/src/routes/directories.ts
@@ -53,7 +53,7 @@ const validator = {
   updateDescription: [param('id').isMongoId(), body('description').isString()],
   updatePages: [param('id').isMongoId(), body('pages').isArray()],
   deleteDirectory: [param('id').isMongoId()],
-  updateEmoji: [param('id').isMongoId(), body('emoji').isString()],
+  updateEmoji: [param('id').isMongoId(), body('emojiId').isString()],
 };
 
 export const directories = (): Router => {
@@ -470,13 +470,13 @@ export const directories = (): Router => {
   // TODO: add swagger by #273
   router.put('/:id/emoji', accessTokenParser, loginRequired, validator.updateEmoji, apiValidatorMiddleware, async (req: WebevRequest, res: Response) => {
     const { id } = req.params;
-    const { emoji } = req.body;
+    const { emojiId } = req.body;
 
     const directoryRepository = new DirectoryRepository();
     const usecase = new UpdateEmojiOfDirectoryUsecase(directoryRepository);
 
     try {
-      const result = await usecase.execute(id, emoji);
+      const result = await usecase.execute(id, emojiId);
 
       return res.status(200).json(result);
     } catch (err) {

--- a/src/usecases/directory/UpdateEmojiOfDirectoryUseCase.ts
+++ b/src/usecases/directory/UpdateEmojiOfDirectoryUseCase.ts
@@ -1,0 +1,14 @@
+import { Directory } from '../../domains/Directory';
+import { IDirectoryRepository } from '../../repositories/IDirectoryRepository';
+
+export class UpdateEmojiOfDirectoryUsecase {
+  private directoryRepository: IDirectoryRepository;
+
+  constructor(directoryRepository: IDirectoryRepository) {
+    this.directoryRepository = directoryRepository;
+  }
+
+  async execute(directoryId: string, emojiId: string): Promise<Directory> {
+    return this.directoryRepository.updateEmoji(directoryId, emojiId);
+  }
+}


### PR DESCRIPTION
# 対象のIssue

fix #272 


## DB
HTTPリクエストを飛ばすことで、emojiIdの更新をしました。

<img width="293" alt="Screen Shot 2021-06-20 at 19 42 54" src="https://user-images.githubusercontent.com/59536731/122671032-bea0b180-d1ff-11eb-9192-4f647405e85c.png">

- defaultの`open_file_folder`から `smile`(仮)に変更
<img width="1123" alt="Screen Shot 2021-06-20 at 19 41 16" src="https://user-images.githubusercontent.com/59536731/122671114-23f4a280-d200-11eb-8bce-cefd9645a4c3.png">

